### PR TITLE
feat: 광고 기능 구현

### DIFF
--- a/src/main/java/com/luckyb/domain/advertisement/controller/AdvertisementController.java
+++ b/src/main/java/com/luckyb/domain/advertisement/controller/AdvertisementController.java
@@ -1,0 +1,54 @@
+package com.luckyb.domain.advertisement.controller;
+
+import com.luckyb.domain.advertisement.dto.AdvertisementRequest;
+import com.luckyb.domain.advertisement.dto.AdvertisementResponse;
+import com.luckyb.domain.advertisement.service.AdvertisementService;
+import com.luckyb.global.common.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/advertisements")
+public class AdvertisementController {
+
+  private final AdvertisementService advertisementService;
+
+  @PostMapping
+  public ResponseEntity<AdvertisementResponse> createAdvertisement(
+      @RequestBody AdvertisementRequest request
+  ) {
+    AdvertisementResponse response = advertisementService.createAdvertisement(request);
+    return ResponseEntity.ok(response);
+  }
+
+  @PutMapping("/{id}")
+  public ResponseEntity<AdvertisementResponse> updateAdvertisement(
+      @PathVariable Long id,
+      @RequestBody AdvertisementRequest request
+  ) {
+    AdvertisementResponse response = advertisementService.updateAdvertisement(id, request);
+    return ResponseEntity.ok(response);
+  }
+
+  @GetMapping("/{id}")
+  public ResponseEntity<AdvertisementResponse> getAdvertisement(@PathVariable Long id) {
+    AdvertisementResponse response = advertisementService.getAdvertisement(id);
+    return ResponseEntity.ok(response);
+  }
+
+  @GetMapping
+  public ResponseEntity<Page<AdvertisementResponse>> getAllAdvertisements(Pageable pageable) {
+    Page<AdvertisementResponse> responses = advertisementService.getAllAdvertisements(pageable);
+    return ResponseEntity.ok(responses);
+  }
+
+  @DeleteMapping("/{id}")
+  public ResponseEntity<ApiResponse<String>> deleteAdvertisement(@PathVariable Long id) {
+    advertisementService.deleteAdvertisement(id);
+    return ResponseEntity.ok(ApiResponse.success("광고가 정상적으로 삭제되었습니다."));
+  }
+}

--- a/src/main/java/com/luckyb/domain/advertisement/dto/AdvertisementRequest.java
+++ b/src/main/java/com/luckyb/domain/advertisement/dto/AdvertisementRequest.java
@@ -1,0 +1,22 @@
+package com.luckyb.domain.advertisement.dto;
+
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Setter
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AdvertisementRequest {
+
+  @Size(min = 2, max = 50)
+  private String title;
+
+  @Size(min = 10, max = 3000)
+  private String content;
+}

--- a/src/main/java/com/luckyb/domain/advertisement/dto/AdvertisementResponse.java
+++ b/src/main/java/com/luckyb/domain/advertisement/dto/AdvertisementResponse.java
@@ -1,0 +1,35 @@
+package com.luckyb.domain.advertisement.dto;
+
+import com.luckyb.domain.advertisement.entity.Advertisement;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AdvertisementResponse {
+
+  private Long id;
+  private String userId;
+  private String title;
+  private String content;
+  private String image;
+  private LocalDateTime createdAt;
+  private LocalDateTime updatedAt;
+
+  public static AdvertisementResponse from(Advertisement advertisement) {
+    return AdvertisementResponse.builder()
+        .id(advertisement.getId())
+        .userId(advertisement.getUser().getUserId())
+        .title(advertisement.getTitle())
+        .content(advertisement.getContent())
+        .image(advertisement.getImage())
+        .createdAt(advertisement.getCreatedAt())
+        .updatedAt(advertisement.getUpdatedAt())
+        .build();
+  }
+}

--- a/src/main/java/com/luckyb/domain/advertisement/entity/Advertisement.java
+++ b/src/main/java/com/luckyb/domain/advertisement/entity/Advertisement.java
@@ -1,0 +1,50 @@
+package com.luckyb.domain.advertisement.entity;
+
+import com.luckyb.domain.user.entity.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Advertisement {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @ManyToOne
+  @JoinColumn(name = "user_id")
+  private User user;
+
+  @Column(name = "title")
+  private String title;
+
+  @Column(name = "content", columnDefinition = "TEXT", nullable = false)
+  private String content;
+
+  @Column(name = "image")
+  private String image;
+
+  @CreationTimestamp
+  private LocalDateTime createdAt;
+
+  @UpdateTimestamp
+  private LocalDateTime updatedAt;
+
+}

--- a/src/main/java/com/luckyb/domain/advertisement/repository/AdvertisementRepository.java
+++ b/src/main/java/com/luckyb/domain/advertisement/repository/AdvertisementRepository.java
@@ -1,0 +1,10 @@
+package com.luckyb.domain.advertisement.repository;
+
+import com.luckyb.domain.advertisement.entity.Advertisement;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface AdvertisementRepository extends JpaRepository<Advertisement, Long> {
+
+}

--- a/src/main/java/com/luckyb/domain/advertisement/service/AdvertisementService.java
+++ b/src/main/java/com/luckyb/domain/advertisement/service/AdvertisementService.java
@@ -1,0 +1,110 @@
+package com.luckyb.domain.advertisement.service;
+
+import static com.luckyb.global.exception.ErrorCode.ADVERTISEMENT_NOT_FOUND;
+
+import com.luckyb.domain.advertisement.dto.AdvertisementRequest;
+import com.luckyb.domain.advertisement.dto.AdvertisementResponse;
+import com.luckyb.domain.advertisement.entity.Advertisement;
+import com.luckyb.domain.advertisement.repository.AdvertisementRepository;
+import com.luckyb.domain.user.entity.User;
+import com.luckyb.domain.user.repository.UserRepository;
+import com.luckyb.global.exception.AdvertisementNotFoundException;
+import com.luckyb.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class AdvertisementService {
+
+  private final AdvertisementRepository advertisementRepository;
+  private final UserRepository userRepository;
+
+  private User getDefaultUser() {
+    return userRepository.findAll()
+        .stream()
+        .findFirst()
+        .orElseGet(() -> userRepository.save(User.createDefaultUser()));
+  }
+
+  public AdvertisementResponse createAdvertisement(AdvertisementRequest request) {
+    User user = getDefaultUser();
+
+    Advertisement advertisement = Advertisement.builder()
+        .user(user)
+        .title(request.getTitle())
+        .content(request.getContent())
+        .build();
+
+    advertisement = advertisementRepository.save(advertisement);
+
+    return AdvertisementResponse.from(advertisement);
+  }
+
+  public Page<AdvertisementResponse> getAllAdvertisements(Pageable pageable) {
+    Page<Advertisement> advertisements = advertisementRepository.findAll(pageable);
+    if (advertisements.isEmpty()) {
+      return Page.empty(pageable);
+    }
+    return advertisements.map(AdvertisementResponse::from);
+  }
+
+  public AdvertisementResponse getAdvertisement(Long id) {
+    Advertisement advertisement = advertisementRepository.findById(id)
+        .orElseThrow(() -> new AdvertisementNotFoundException(ADVERTISEMENT_NOT_FOUND));
+    return AdvertisementResponse.from(advertisement);
+  }
+
+  @Transactional
+  public AdvertisementResponse updateAdvertisement(Long id, AdvertisementRequest request) {
+    User user = getDefaultUser();
+
+    Advertisement advertisement = advertisementRepository.findById(id)
+        .orElseThrow(() -> new AdvertisementNotFoundException(ADVERTISEMENT_NOT_FOUND));
+
+    // 광고 작성자와 기본 유저가 다르면 수정 불가 (대회용 기본 유저라 항상 허용 가능)
+    if (!advertisement.getUser().equals(user)) {
+      throw new AdvertisementNotFoundException(ErrorCode.ACCESS_DENIED);
+    }
+
+    Advertisement updated = updateAdvertisementFields(advertisement, request);
+    advertisementRepository.save(updated);
+
+    return AdvertisementResponse.from(updated);
+  }
+
+  @Transactional
+  public void deleteAdvertisement(Long id) {
+    User user = getDefaultUser();
+
+    Advertisement advertisement = advertisementRepository.findById(id)
+        .orElseThrow(() -> new AdvertisementNotFoundException(ADVERTISEMENT_NOT_FOUND));
+
+    if (!advertisement.getUser().equals(user)) {
+      throw new AdvertisementNotFoundException(ErrorCode.ACCESS_DENIED);
+    }
+
+    advertisementRepository.delete(advertisement);
+  }
+
+  private Advertisement updateAdvertisementFields(Advertisement advertisement,
+      AdvertisementRequest request) {
+    String updatedTitle = (request.getTitle() != null && !request.getTitle().trim().isEmpty())
+        ? request.getTitle() : advertisement.getTitle();
+    String updatedContent = (request.getContent() != null && !request.getContent().trim().isEmpty())
+        ? request.getContent() : advertisement.getContent();
+
+    return Advertisement.builder()
+        .id(advertisement.getId())
+        .user(advertisement.getUser())
+        .title(updatedTitle)
+        .content(updatedContent)
+        .image(advertisement.getImage())
+        .createdAt(advertisement.getCreatedAt())
+        .updatedAt(advertisement.getUpdatedAt())
+        .build();
+  }
+}

--- a/src/main/java/com/luckyb/global/exception/AdvertisementNotFoundException.java
+++ b/src/main/java/com/luckyb/global/exception/AdvertisementNotFoundException.java
@@ -1,0 +1,15 @@
+package com.luckyb.global.exception;
+
+import lombok.Getter;
+
+@Getter
+public class AdvertisementNotFoundException extends RuntimeException {
+
+  private final ErrorCode errorCode;
+
+  public AdvertisementNotFoundException(ErrorCode errorCode) {
+    super(errorCode.getMessage());
+    this.errorCode = errorCode;
+  }
+
+}

--- a/src/main/java/com/luckyb/global/exception/ErrorCode.java
+++ b/src/main/java/com/luckyb/global/exception/ErrorCode.java
@@ -14,6 +14,7 @@ public enum ErrorCode {
     AUTHENTICATION_FAILED("A001", "인증에 실패했습니다"),
     TOKEN_EXPIRED("A002", "토큰이 만료되었습니다"),
     INVALID_CREDENTIALS("A003", "잘못된 인증 정보입니다"),
+    ACCESS_DENIED("A004","접근이 거부되었습니다."),
     
     // 쉼터 관련 에러
     SHELTER_NOT_FOUND("SH001", "쉼터를 찾을 수 없습니다"),
@@ -22,6 +23,14 @@ public enum ErrorCode {
     SHELTER_CREATION_FAILED("SH004", "쉼터 생성에 실패했습니다"),
     SHELTER_UPDATE_FAILED("SH005", "쉼터 수정에 실패했습니다"),
     SHELTER_DELETE_FAILED("SH006", "쉼터 삭제에 실패했습니다"),
+
+    // 광고 관련 에러
+    ADVERTISEMENT_NOT_FOUND("AD001", "광고를 찾을 수 없습니다"),
+    ADVERTISEMENT_CREATION_FAILED("AD002", "광고 생성에 실패했습니다"),
+    ADVERTISEMENT_UPDATE_FAILED("AD003", "광고 수정에 실패했습니다"),
+    ADVERTISEMENT_DELETE_FAILED("AD004", "광고 삭제에 실패했습니다"),
+    INVALID_ADVERTISEMENT_INPUT("AD005", "광고 입력값이 올바르지 않습니다"),
+
     
     // 시스템 에러
     INTERNAL_SERVER_ERROR("S001", "서버 내부 오류가 발생했습니다"),


### PR DESCRIPTION
### 변경사항
- Controller
  - @RestController, @RequestMapping("/api/v1/advertisements") 적용
  - CRUD API 구현
    - POST /api/v1/advertisements : 광고 생성
    - PUT /api/v1/advertisements/{id} : 광고 수정
    - GET /api/v1/advertisements/{id} : 단일 광고 조회
    - GET /api/v1/advertisements : 광고 전체 조회 (페이지네이션 적용)
    - DELETE /api/v1/advertisements/{id} : 광고 삭제
- DTO
  - AdvertisementRequest (광고 생성/수정 요청 DTO)
    - title : 2~50자
    - content : 10~3000자
  - AdvertisementResponse (광고 조회/응답 DTO)
    - id : 광고 PK
    - userId : 작성자 ID
    - title : 광고 제목
    - content : 광고 내용
    - image : 이미지 경로
    - createdAt : 생성일 (LocalDateTime)
    - updatedAt : 수정일 (LocalDateTime)
    - Entity → DTO 변환 메서드 제공 (from())
- Entity
    - @Entity 매핑
    - id (PK, 자동생성)
    - user (작성자, @ManyToOne)
    - title, content, image
    - createdAt (@CreationTimestamp)
    - updatedAt (@UpdateTimestamp)
    - Repository
- AdvertisementRepository
  - JpaRepository<Advertisement, Long> 상속
기본 CRUD 기능 제공
- Service
  - createAdvertisement : 광고 생성
  - getAllAdvertisements : 광고 전체 조회 (페이지네이션)
  - getAdvertisement : 단건 조회
  - updateAdvertisement : 광고 수정
  - deleteAdvertisement : 광고 삭제
  - getDefaultUser() : 기본 유저 처리 (대회용 단일 유저)
  - updateAdvertisementFields() : null/빈값 방지
- Exception
  - AdvertisementNotFoundException
  - 광고 미존재 또는 접근 권한 오류 처리
  - ErrorCode (광고 관련 에러 코드 추가)
    - ADVERTISEMENT_NOT_FOUND : 광고를 찾을 수 없음
    - ADVERTISEMENT_CREATION_FAILED : 광고 생성 실패
    - ADVERTISEMENT_UPDATE_FAILED : 광고 수정 실패
    - ADVERTISEMENT_DELETE_FAILED : 광고 삭제 실패
    - INVALID_ADVERTISEMENT_INPUT : 광고 입력값 오류