### PR TITLE
refactor: 좋아요 토글 수정

### DIFF
--- a/src/main/java/com/luckyb/domain/like/repository/LikeRepository.java
+++ b/src/main/java/com/luckyb/domain/like/repository/LikeRepository.java
@@ -2,12 +2,14 @@ package com.luckyb.domain.like.repository;
 
 import com.luckyb.domain.like.entity.Like;
 import com.luckyb.domain.shelter.entity.Shelter;
-import java.util.List;
+import com.luckyb.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface LikeRepository extends JpaRepository<Like, Long> {
 
-  List<Like> findAllByShelter(Shelter shelter);
+  boolean existsByShelterAndUser(Shelter shelter, User userId);
+
+  void deleteByShelterAndUser(Shelter shelter, User userId);
 }

--- a/src/main/java/com/luckyb/domain/shelter/controller/ShelterController.java
+++ b/src/main/java/com/luckyb/domain/shelter/controller/ShelterController.java
@@ -1,12 +1,12 @@
 package com.luckyb.domain.shelter.controller;
 
 import com.luckyb.domain.shelter.dto.*;
-import com.luckyb.domain.shelter.entity.Shelter;
-import com.luckyb.domain.shelter.repository.ShelterRepository;
 import com.luckyb.domain.shelter.service.ShelterService;
 import com.luckyb.domain.shelter.service.AiShelterService;
 import com.luckyb.global.common.ApiResponse;
-import java.util.stream.Collectors;
+import com.luckyb.global.exception.ErrorCode;
+import com.luckyb.global.exception.InvalidTokenException;
+import com.luckyb.global.jwt.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.*;
@@ -21,7 +21,7 @@ public class ShelterController {
 
   private final ShelterService shelterService;
   private final AiShelterService aiShelterService;
-  private final ShelterRepository shelterRepository;
+  private final JwtTokenProvider jwtTokenProvider;
 
   /**
    * 쉼터 목록 조회 (위치 기반)
@@ -131,31 +131,21 @@ public class ShelterController {
     return ApiResponse.success(response);
   }
 
-  /*  @PutMapping("/{shelterId}/like")
-    public ResponseEntity<String> toggleLike(@PathVariable String shelterId) {
-      shelterService.toggleLike(shelterId);
-      return ResponseEntity.ok("좋아요 토글 완료");
-    }*/
+  @PutMapping("/{shelterId}/like")
+  public ApiResponse<String> toggleLike(
+      @PathVariable String shelterId,
+      @RequestHeader("Authorization") String authorization
+  ) {
+    // JWT 토큰에서 사용자 ID 추출
+    String token = jwtTokenProvider.resolveToken(authorization);
+    if (token == null || !jwtTokenProvider.validateToken(token)) {
+      throw new InvalidTokenException(ErrorCode.INVALID_TOKEN);
+    }
 
-  @PostMapping("/{shelterId}/likes")
-  public ApiResponse<String> likeShelter(@PathVariable String shelterId) {
-    shelterService.addLike(shelterId);
-    return ApiResponse.success("좋아요 등록 완료");
+    String userId = jwtTokenProvider.getUserIdFromToken(token);
+
+    shelterService.toggleLike(shelterId, userId);
+    return ApiResponse.success("좋아요 토글 완료");
   }
 
-  @DeleteMapping("/{shelterId}/likes")
-  public ApiResponse<String> unlikeShelter(@PathVariable String shelterId) {
-    shelterService.removeLike(shelterId);
-    return ApiResponse.success("좋아요 취소 완료");
-  }
-
-  @GetMapping("/likes")
-  public ApiResponse<List<ShelterLikeResponse>> getLikes() {
-    List<Shelter> shelters = shelterRepository.findAll();
-    List<ShelterLikeResponse> response = shelters.stream()
-        .map(s -> new ShelterLikeResponse(s.getShelterId(), s.getLikeCount()))
-        .collect(Collectors.toList());
-
-    return ApiResponse.success(response);
-  }
 }

--- a/src/main/java/com/luckyb/domain/shelter/entity/Shelter.java
+++ b/src/main/java/com/luckyb/domain/shelter/entity/Shelter.java
@@ -5,6 +5,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 
@@ -19,178 +20,179 @@ import java.util.UUID;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Shelter {
 
-    @Id
-    @Column(name = "shelter_id", updatable = false, nullable = false)
-    private String shelterId;
+  @Id
+  @Column(name = "shelter_id", updatable = false, nullable = false)
+  private String shelterId;
 
-    @Column(name = "name", nullable = false, length = 100)
-    private String name;
+  @Column(name = "name", nullable = false, length = 100)
+  private String name;
 
-    @Embedded
-    private Address address;
+  @Embedded
+  private Address address;
 
-    @Embedded
-    private Coordinates coordinates;
+  @Embedded
+  private Coordinates coordinates;
 
-    @Enumerated(EnumType.STRING)
-    @Column(name = "type", nullable = false)
-    private ShelterType type;
+  @Enumerated(EnumType.STRING)
+  @Column(name = "type", nullable = false)
+  private ShelterType type;
 
-    @Column(name = "capacity", nullable = false)
-    private Integer capacity;
+  @Column(name = "capacity", nullable = false)
+  private Integer capacity;
 
-    @ElementCollection(fetch = FetchType.LAZY)
-    @CollectionTable(
-        name = "shelter_facilities",
-        joinColumns = @JoinColumn(name = "shelter_id")
-    )
-    @Column(name = "facility")
-    private List<String> facilities = new ArrayList<>();
+  @ElementCollection(fetch = FetchType.LAZY)
+  @CollectionTable(
+      name = "shelter_facilities",
+      joinColumns = @JoinColumn(name = "shelter_id")
+  )
+  @Column(name = "facility")
+  private List<String> facilities = new ArrayList<>();
 
-    @Column(name = "operating_hours", length = 100)
-    private String operatingHours;
+  @Column(name = "operating_hours", length = 100)
+  private String operatingHours;
 
-    @Enumerated(EnumType.STRING)
-    @Column(name = "status", nullable = false)
-    private ShelterStatus status;
+  @Enumerated(EnumType.STRING)
+  @Column(name = "status", nullable = false)
+  private ShelterStatus status;
 
-    @Column(name = "like_count")
-    private Integer likeCount = 0;
+  @Setter
+  @Column(name = "like_count")
+  private Integer likeCount = 0;
 
-    @Column(name = "review_count")
-    private Integer reviewCount = 0;
+  @Column(name = "review_count")
+  private Integer reviewCount = 0;
 
-    @Column(name = "description", length = 500)
-    private String description;
+  @Column(name = "description", length = 500)
+  private String description;
 
-    @CreationTimestamp
-    @Column(name = "created_at", updatable = false)
-    private LocalDateTime createdAt;
+  @CreationTimestamp
+  @Column(name = "created_at", updatable = false)
+  private LocalDateTime createdAt;
 
-    @UpdateTimestamp
-    @Column(name = "updated_at")
-    private LocalDateTime updatedAt;
+  @UpdateTimestamp
+  @Column(name = "updated_at")
+  private LocalDateTime updatedAt;
 
-    @Builder
-    public Shelter(String name, Address address, Coordinates coordinates, ShelterType type,
-                   Integer capacity, List<String> facilities, String operatingHours, String description) {
-        this.shelterId = UUID.randomUUID().toString();
-        this.name = name;
-        this.address = address;
-        this.coordinates = coordinates;
-        this.type = type;
-        this.capacity = capacity;
-        this.facilities = facilities != null ? facilities : new ArrayList<>();
-        this.operatingHours = operatingHours;
-        this.status = ShelterStatus.ACTIVE;
-        this.description = description;
-        this.likeCount = 0;
-        this.reviewCount = 0;
+  @Builder
+  public Shelter(String name, Address address, Coordinates coordinates, ShelterType type,
+      Integer capacity, List<String> facilities, String operatingHours, String description) {
+    this.shelterId = UUID.randomUUID().toString();
+    this.name = name;
+    this.address = address;
+    this.coordinates = coordinates;
+    this.type = type;
+    this.capacity = capacity;
+    this.facilities = facilities != null ? facilities : new ArrayList<>();
+    this.operatingHours = operatingHours;
+    this.status = ShelterStatus.ACTIVE;
+    this.description = description;
+    this.likeCount = 0;
+    this.reviewCount = 0;
+  }
+
+  // 쉼터 정보 수정 메서드
+  public void updateShelterInfo(String name, Address address, Coordinates coordinates,
+      ShelterType type, Integer capacity, List<String> facilities,
+      String operatingHours, String description) {
+    if (name != null) {
+      this.name = name;
+    }
+    if (address != null) {
+      this.address = address;
+    }
+    if (coordinates != null) {
+      this.coordinates = coordinates;
+    }
+    if (type != null) {
+      this.type = type;
+    }
+    if (capacity != null) {
+      this.capacity = capacity;
+    }
+    if (facilities != null) {
+      this.facilities = new ArrayList<>(facilities);
+    }
+    if (operatingHours != null) {
+      this.operatingHours = operatingHours;
+    }
+    if (description != null) {
+      this.description = description;
+    }
+  }
+
+  // 좋아요 수 증가 메서드
+  public void increaseLikeCount() {
+    this.likeCount++;
+  }
+
+  // 좋아요 수 감소 메서드
+  public void decreaseLikeCount() {
+    if (this.likeCount > 0) {
+      this.likeCount--;
+    }
+  }
+
+  // 리뷰 수 증가 메서드
+  public void increaseReviewCount() {
+    this.reviewCount++;
+  }
+
+  // 상태 변경 메서드
+  public void updateStatus(ShelterStatus status) {
+    this.status = status;
+  }
+
+  // 쉼터 타입 열거형
+  public enum ShelterType {
+    PUBLIC("public"),           // 공공시설
+    PRIVATE("private"),         // 민간시설
+    COMMERCIAL("commercial"),   // 상업시설
+    COMMUNITY("community");     // 커뮤니티 시설
+
+    private final String value;
+
+    ShelterType(String value) {
+      this.value = value;
     }
 
-    // 쉼터 정보 수정 메서드
-    public void updateShelterInfo(String name, Address address, Coordinates coordinates, 
-                                 ShelterType type, Integer capacity, List<String> facilities,
-                                 String operatingHours, String description) {
-        if (name != null) {
-            this.name = name;
-        }
-        if (address != null) {
-            this.address = address;
-        }
-        if (coordinates != null) {
-            this.coordinates = coordinates;
-        }
-        if (type != null) {
-            this.type = type;
-        }
-        if (capacity != null) {
-            this.capacity = capacity;
-        }
-        if (facilities != null) {
-            this.facilities = new ArrayList<>(facilities);
-        }
-        if (operatingHours != null) {
-            this.operatingHours = operatingHours;
-        }
-        if (description != null) {
-            this.description = description;
-        }
+    public String getValue() {
+      return value;
     }
 
-    // 좋아요 수 증가 메서드
-    public void increaseLikeCount() {
-        this.likeCount++;
+    public static ShelterType fromValue(String value) {
+      for (ShelterType type : ShelterType.values()) {
+        if (type.getValue().equals(value)) {
+          return type;
+        }
+      }
+      throw new IllegalArgumentException("Unknown shelter type: " + value);
+    }
+  }
+
+  // 쉼터 상태 열거형
+  public enum ShelterStatus {
+    ACTIVE("active"),           // 운영 중
+    INACTIVE("inactive"),       // 운영 중지
+    MAINTENANCE("maintenance"), // 점검 중
+    FULL("full");              // 만석
+
+    private final String value;
+
+    ShelterStatus(String value) {
+      this.value = value;
     }
 
-    // 좋아요 수 감소 메서드
-    public void decreaseLikeCount() {
-        if (this.likeCount > 0) {
-            this.likeCount--;
-        }
+    public String getValue() {
+      return value;
     }
 
-    // 리뷰 수 증가 메서드
-    public void increaseReviewCount() {
-        this.reviewCount++;
+    public static ShelterStatus fromValue(String value) {
+      for (ShelterStatus status : ShelterStatus.values()) {
+        if (status.getValue().equals(value)) {
+          return status;
+        }
+      }
+      throw new IllegalArgumentException("Unknown shelter status: " + value);
     }
-
-    // 상태 변경 메서드
-    public void updateStatus(ShelterStatus status) {
-        this.status = status;
-    }
-
-    // 쉼터 타입 열거형
-    public enum ShelterType {
-        PUBLIC("public"),           // 공공시설
-        PRIVATE("private"),         // 민간시설
-        COMMERCIAL("commercial"),   // 상업시설
-        COMMUNITY("community");     // 커뮤니티 시설
-
-        private final String value;
-
-        ShelterType(String value) {
-            this.value = value;
-        }
-
-        public String getValue() {
-            return value;
-        }
-
-        public static ShelterType fromValue(String value) {
-            for (ShelterType type : ShelterType.values()) {
-                if (type.getValue().equals(value)) {
-                    return type;
-                }
-            }
-            throw new IllegalArgumentException("Unknown shelter type: " + value);
-        }
-    }
-
-    // 쉼터 상태 열거형
-    public enum ShelterStatus {
-        ACTIVE("active"),           // 운영 중
-        INACTIVE("inactive"),       // 운영 중지
-        MAINTENANCE("maintenance"), // 점검 중
-        FULL("full");              // 만석
-
-        private final String value;
-
-        ShelterStatus(String value) {
-            this.value = value;
-        }
-
-        public String getValue() {
-            return value;
-        }
-
-        public static ShelterStatus fromValue(String value) {
-            for (ShelterStatus status : ShelterStatus.values()) {
-                if (status.getValue().equals(value)) {
-                    return status;
-                }
-            }
-            throw new IllegalArgumentException("Unknown shelter status: " + value);
-        }
-    }
+  }
 } 

--- a/src/main/java/com/luckyb/domain/shelter/service/ShelterService.java
+++ b/src/main/java/com/luckyb/domain/shelter/service/ShelterService.java
@@ -1,8 +1,12 @@
 package com.luckyb.domain.shelter.service;
 
+import com.luckyb.domain.like.entity.Like;
+import com.luckyb.domain.like.repository.LikeRepository;
 import com.luckyb.domain.shelter.dto.*;
 import com.luckyb.domain.shelter.entity.Shelter;
 import com.luckyb.domain.shelter.repository.ShelterRepository;
+import com.luckyb.domain.user.entity.User;
+import com.luckyb.domain.user.repository.UserRepository;
 import com.luckyb.global.exception.ErrorCode;
 import com.luckyb.global.exception.ShelterNotFoundException;
 import lombok.RequiredArgsConstructor;
@@ -27,6 +31,8 @@ public class ShelterService {
   private final LocationService locationService;
   private final RecommendationService recommendationService;
   private final CongestionPredictionService congestionPredictionService;
+  private final LikeRepository likeRepository;
+  private final UserRepository userRepository;
 
   // 기본 검색 반경 (km)
   private static final double DEFAULT_SEARCH_RADIUS = 5.0;
@@ -239,24 +245,34 @@ public class ShelterService {
         .build();
   }
 
+  /**
+   * 쉼터 좋아요
+   */
   @Transactional
-  public void addLike(String shelterId) {
+  public void toggleLike(String shelterId, String userId) {
     Shelter shelter = shelterRepository.findById(shelterId)
-        .orElseThrow(() -> new IllegalArgumentException("유효하지 않은 쉼터 ID 입니다."));
+        .orElseThrow(() -> new IllegalArgumentException("유효하지 않은 쉼터 ID입니다."));
 
-    shelter.increaseLikeCount();
+    User user = userRepository.findById(userId)
+        .orElseThrow(() -> new IllegalArgumentException("유효하지 않은 사용자 ID입니다."));
+
+    boolean alreadyLiked = likeRepository.existsByShelterAndUser(shelter, user);
+
+    if (alreadyLiked) {
+      // 이미 좋아요 상태라면 취소
+      shelter.setLikeCount(shelter.getLikeCount() - 1);
+      likeRepository.deleteByShelterAndUser(shelter, user);
+    } else {
+      // 좋아요 추가
+      shelter.setLikeCount(shelter.getLikeCount() + 1);
+      Like like = new Like();
+      like.setShelter(shelter);
+      like.setUser(user);
+      likeRepository.save(like);
+    }
+
     shelterRepository.save(shelter);
   }
-
-  @Transactional
-  public void removeLike(String shelterId) {
-    Shelter shelter = shelterRepository.findById(shelterId)
-        .orElseThrow(() -> new IllegalArgumentException("유효하지 않은 쉼터 ID 입니다."));
-
-    shelter.decreaseLikeCount();
-    shelterRepository.save(shelter);
-  }
-
   // === Private Helper Methods ===
 
   private Shelter findActiveShelterById(String shelterId) {


### PR DESCRIPTION
   ### 변경사항
- 기존 구현 (삭제됨)
  - 좋아요 등록 / 취소를 분리된 API로 구현
    - POST /{shelterId}/likes → 좋아요 등록
    - DELETE /{shelterId}/likes → 좋아요 취소
  - Shelter 엔티티의 likeCount 만 증가/감소 처리
   - 특정 사용자가 어떤 쉼터에 좋아요를 눌렀는지 정보(User-Shelter 매핑)가 없었음 → 중복 좋아요 방지 불가능
-  변경 후 구현
  - 토글 방식으로 개선
    - PUT /{shelterId}/like → 좋아요 누르면 추가, 다시 누르면 취소
  -  Like 엔티티 추가
    - Shelter 와 User 관계를 저장 → 누가 어떤 쉼터에 좋아요 눌렀는지 추적 가능
  - LikeRepository 구현
    - existsByShelterAndUser(...) 로 좋아요 여부 확인
    - deleteByShelterAndUser(...) 로 취소 처리
  - ShelterService.toggleLike(...) 로 단일 메소드에서 좋아요 상태 전환 가능
  - likeCount 는 여전히 Shelter 엔티티에 반영하여 집계 성능 유지
  
     ### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [X] API 테스트 