### PR TITLE
feat: 검색 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,10 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.3'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.3'
-    
+
+    // ELASTICSEARCH
+    implementation 'org.springframework.boot:spring-boot-starter-data-elasticsearch'
+
     // Database - MariaDB
     runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
     

--- a/src/main/java/com/luckyb/domain/search/ElasticRepository.java
+++ b/src/main/java/com/luckyb/domain/search/ElasticRepository.java
@@ -1,0 +1,9 @@
+package com.luckyb.domain.search;
+
+import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ElasticRepository extends ElasticsearchRepository<ShelterDocument, String> {
+
+}

--- a/src/main/java/com/luckyb/domain/search/SearchController.java
+++ b/src/main/java/com/luckyb/domain/search/SearchController.java
@@ -1,0 +1,28 @@
+package com.luckyb.domain.search;
+
+import com.luckyb.domain.shelter.dto.ShelterDetailResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequestMapping("/api/v1/search")
+@RestController
+@RequiredArgsConstructor
+public class SearchController {
+
+  private final SearchService searchService;
+
+  @GetMapping("/shelters")
+  public ResponseEntity<Page<ShelterDetailResponse>> searchShelter(
+      @PageableDefault Pageable pageable,
+      @RequestParam String name
+  ) {
+    return ResponseEntity.ok(searchService.searchShelterByName(pageable, name));
+  }
+}

--- a/src/main/java/com/luckyb/domain/search/SearchService.java
+++ b/src/main/java/com/luckyb/domain/search/SearchService.java
@@ -1,0 +1,72 @@
+package com.luckyb.domain.search;
+
+import com.luckyb.domain.shelter.dto.ShelterDetailResponse;
+import com.luckyb.domain.shelter.entity.Shelter;
+import com.luckyb.domain.shelter.repository.ShelterRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
+import co.elastic.clients.elasticsearch._types.query_dsl.QueryBuilders;
+import org.springframework.data.elasticsearch.client.elc.NativeQuery;
+import org.springframework.data.elasticsearch.client.elc.NativeQueryBuilder;
+import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
+import org.springframework.data.elasticsearch.core.SearchHits;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class SearchService {
+
+  private final ElasticsearchOperations elasticsearchOperations;
+  private final ElasticRepository elasticRepository;
+  private final ShelterRepository shelterRepository;
+
+  public void save(Shelter shelter) {
+    String cleanedName = StringUtils.trimAllWhitespace(shelter.getName());
+
+    ShelterDocument doc = ShelterDocument.builder()
+        .id(shelter.getShelterId())
+        .name(cleanedName)
+        .build();
+    elasticRepository.save(doc);
+  }
+
+  public void delete(String shelterId) {
+    elasticRepository.deleteById(shelterId);
+  }
+
+  public Page<ShelterDetailResponse> searchShelterByName(Pageable pageable, String shelterName) {
+
+    Query query = QueryBuilders.match()
+        .query(StringUtils.trimAllWhitespace(shelterName))
+        .field("name")
+        .build()
+        ._toQuery();
+
+    NativeQuery nativeQuery = new NativeQueryBuilder()
+        .withQuery(query)
+        .withPageable(pageable)
+        .build();
+
+    SearchHits<ShelterDocument> searchHits =
+        elasticsearchOperations.search(nativeQuery, ShelterDocument.class);
+
+    List<String> shelterIds = searchHits.get()
+        .map(hit -> hit.getContent().getId())
+        .collect(Collectors.toList());
+
+    List<ShelterDetailResponse> shelters = shelterRepository.findAllById(shelterIds).stream()
+        .map(ShelterDetailResponse::from)
+        .collect(Collectors.toList());
+
+    return new PageImpl<>(shelters, pageable, searchHits.getTotalHits());
+  }
+}

--- a/src/main/java/com/luckyb/domain/search/ShelterDocument.java
+++ b/src/main/java/com/luckyb/domain/search/ShelterDocument.java
@@ -1,0 +1,22 @@
+package com.luckyb.domain.search;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.elasticsearch.annotations.Document;
+import org.springframework.data.elasticsearch.annotations.Mapping;
+import org.springframework.data.elasticsearch.annotations.Setting;
+
+@Getter
+@Setter
+@Builder
+@Setting(settingPath = "/elasticsearch/settings/settings.json", replicas = 0)
+@Mapping(mappingPath = "/elasticsearch/mappings/mappings.json")
+@Document(indexName = "shelter")
+public class ShelterDocument {
+
+  @Id
+  private String id;
+  private String name;
+}

--- a/src/main/java/com/luckyb/domain/shelter/service/ShelterService.java
+++ b/src/main/java/com/luckyb/domain/shelter/service/ShelterService.java
@@ -2,6 +2,7 @@ package com.luckyb.domain.shelter.service;
 
 import com.luckyb.domain.like.entity.Like;
 import com.luckyb.domain.like.repository.LikeRepository;
+import com.luckyb.domain.search.SearchService;
 import com.luckyb.domain.shelter.dto.*;
 import com.luckyb.domain.shelter.entity.Shelter;
 import com.luckyb.domain.shelter.repository.ShelterRepository;
@@ -29,6 +30,7 @@ public class ShelterService {
 
   private final ShelterRepository shelterRepository;
   private final LocationService locationService;
+  private final SearchService searchService;
   private final RecommendationService recommendationService;
   private final CongestionPredictionService congestionPredictionService;
   private final LikeRepository likeRepository;
@@ -92,6 +94,8 @@ public class ShelterService {
       Shelter shelter = request.toEntity();
       Shelter savedShelter = shelterRepository.save(shelter);
 
+      searchService.save(savedShelter);
+
       log.info("새 쉼터가 등록되었습니다. shelterId: {}, name: {}",
           savedShelter.getShelterId(), savedShelter.getName());
 
@@ -148,6 +152,7 @@ public class ShelterService {
       // 소프트 삭제: 상태를 INACTIVE로 변경
       shelter.updateStatus(Shelter.ShelterStatus.INACTIVE);
       shelterRepository.save(shelter);
+      searchService.delete(shelterId);
 
       log.info("쉼터가 삭제되었습니다. shelterId: {}", shelterId);
 

--- a/src/main/java/com/luckyb/global/config/ElasticSearchConfig.java
+++ b/src/main/java/com/luckyb/global/config/ElasticSearchConfig.java
@@ -1,0 +1,89 @@
+package com.luckyb.global.config;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.json.jackson.JacksonJsonpMapper;
+import co.elastic.clients.transport.ElasticsearchTransport;
+import co.elastic.clients.transport.rest_client.RestClientTransport;
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.X509Certificate;
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.http.HttpHost;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.elasticsearch.client.RestClient;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.elasticsearch.repository.config.EnableElasticsearchRepositories;
+
+@Slf4j
+@Configuration
+@EnableElasticsearchRepositories(basePackages = "com.luckyb.domain.search")
+public class ElasticSearchConfig {
+
+  @Value("${spring.data.elasticsearch.url}")
+  private String host;
+
+  @Value("${spring.data.elasticsearch.username}")
+  private String username;
+
+  @Value("${spring.data.elasticsearch.password}")
+  private String password;
+
+  @Bean
+  public ElasticsearchClient elasticsearchClient() {
+    // Basic Auth
+    BasicCredentialsProvider credentialsProvider = new BasicCredentialsProvider();
+    credentialsProvider.setCredentials(
+        AuthScope.ANY,
+        new UsernamePasswordCredentials(username, password)
+    );
+
+    RestClient restClient = RestClient.builder(HttpHost.create(host))
+        .setHttpClientConfigCallback(httpClientBuilder ->
+            httpClientBuilder
+                .setSSLContext(disableSslVerification())  // SSL 무시
+                .setSSLHostnameVerifier(allHostsValid())  // Hostname 검증 무시
+                .setDefaultCredentialsProvider(credentialsProvider) // 인증 적용
+        )
+        .build();
+
+    ElasticsearchTransport transport = new RestClientTransport(restClient,
+        new JacksonJsonpMapper());
+    return new ElasticsearchClient(transport);
+  }
+
+  public static SSLContext disableSslVerification() {
+    try {
+      TrustManager[] trustAllCerts = new TrustManager[]{
+          new X509TrustManager() {
+            public X509Certificate[] getAcceptedIssuers() {
+              return null;
+            }
+
+            public void checkClientTrusted(X509Certificate[] certs, String authType) {
+            }
+
+            public void checkServerTrusted(X509Certificate[] certs, String authType) {
+            }
+          }
+      };
+      SSLContext sc = SSLContext.getInstance("SSL");
+      sc.init(null, trustAllCerts, new java.security.SecureRandom());
+      return sc;
+    } catch (NoSuchAlgorithmException | KeyManagementException e) {
+      log.warn(e.getMessage());
+    }
+    return null;
+  }
+
+  public static HostnameVerifier allHostsValid() {
+    return (hostname, session) -> true;
+  }
+}

--- a/src/main/resources/elasticsearch/mappings/mappings.json
+++ b/src/main/resources/elasticsearch/mappings/mappings.json
@@ -1,0 +1,7 @@
+{
+  "properties": {
+    "name": {
+      "type": "keyword"
+    }
+  }
+}

--- a/src/main/resources/elasticsearch/settings/settings.json
+++ b/src/main/resources/elasticsearch/settings/settings.json
@@ -1,0 +1,11 @@
+{
+  "number_of_shards": 1,
+  "number_of_replicas": 0,
+  "analysis": {
+    "analyzer": {
+      "default": {
+        "type": "standard"
+      }
+    }
+  }
+}


### PR DESCRIPTION
### 변경사항
- Config
  - ElasticSearchConfig
    - ElasticsearchClient Bean 등록
    - Basic Auth 적용 (username/password)
    - SSL/Hostname 검증 무시 설정 (대회 환경 대응)
    - `@EnableElasticsearchRepositories` 추가
- Document
  - ShelterDocument
    - Elasticsearch 인덱스 매핑용 Document 클래스
    - id, name 필드 포함
    - `@Document(indexName = "shelter")`
    - `@Setting, @Mapping` 으로 settings.json, mappings.json 적용
- Repository
  - ElasticRepository
    - `ElasticsearchRepository<ShelterDocument, String>` 상속
기본 CRUD 인덱싱 기능 제공
- Service
  - SearchService
    - save(Shelter shelter) : 쉼터 저장 시 Elasticsearch 문서로 인덱싱
    - `StringUtils.trimAllWhitespace()` 적용 → "가나 다라"와 "가나다라" 동일하게 검색 가능
    - delete(String shelterId) : 문서 삭제
    -` searchShelterByName(Pageable, String)` : 이름 검색
    - 입력값 공백 제거 후 match 쿼리 실행
    - `Elasticsearch` 결과 ID 기반 DB 조회 → `ShelterDetailResponse` 반환
- Controller
  - SearchController
    - `GET /api/v1/search/shelters` : 이름 기반 쉼터 검색 (페이지네이션 지원)
- Resource (설정 파일)
  - `/resources/elasticsearch/settings/settings.json`
    - 샤드/레플리카 설정, 기본 analyzer 설정
  - `/resources/elasticsearch/mappings/mappings.json`
    - name 필드를 keyword 타입으로 매핑
- Dependency
  - `implementation 'org.springframework.boot:spring-boot-starter-data-elasticsearch'` 추가
  
     ### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [X] API 테스트 