### PR TITLE
feat: 좋아요 리스트 기능 구현

### DIFF
--- a/src/main/java/com/luckyb/domain/like/repository/LikeRepository.java
+++ b/src/main/java/com/luckyb/domain/like/repository/LikeRepository.java
@@ -3,6 +3,7 @@ package com.luckyb.domain.like.repository;
 import com.luckyb.domain.like.entity.Like;
 import com.luckyb.domain.shelter.entity.Shelter;
 import com.luckyb.domain.user.entity.User;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -12,4 +13,6 @@ public interface LikeRepository extends JpaRepository<Like, Long> {
   boolean existsByShelterAndUser(Shelter shelter, User userId);
 
   void deleteByShelterAndUser(Shelter shelter, User userId);
+
+  List<Like> findByShelter_ShelterId(String shelterId);
 }

--- a/src/main/java/com/luckyb/domain/shelter/controller/ShelterController.java
+++ b/src/main/java/com/luckyb/domain/shelter/controller/ShelterController.java
@@ -170,4 +170,12 @@ public class ShelterController {
     return ApiResponse.success("좋아요 토글 완료");
   }
 
+  @GetMapping("/{shelterId}/likes")
+  public ApiResponse<List<String>> getShelterLikes(
+      @PathVariable String shelterId
+  ) {
+    List<String> nicknames = shelterService.getShelterLikeUsers(shelterId);
+    return ApiResponse.success(nicknames);
+  }
+
 }

--- a/src/main/java/com/luckyb/domain/shelter/service/ShelterService.java
+++ b/src/main/java/com/luckyb/domain/shelter/service/ShelterService.java
@@ -273,11 +273,9 @@ public class ShelterService {
     boolean alreadyLiked = likeRepository.existsByShelterAndUser(shelter, user);
 
     if (alreadyLiked) {
-      // 이미 좋아요 상태라면 취소
       shelter.setLikeCount(shelter.getLikeCount() - 1);
       likeRepository.deleteByShelterAndUser(shelter, user);
     } else {
-      // 좋아요 추가
       shelter.setLikeCount(shelter.getLikeCount() + 1);
       Like like = new Like();
       like.setShelter(shelter);
@@ -288,6 +286,13 @@ public class ShelterService {
     }
 
     shelterRepository.save(shelter);
+  }
+
+  public List<String> getShelterLikeUsers(String shelterId) {
+    return likeRepository.findByShelter_ShelterId(shelterId)
+        .stream()
+        .map(like -> like.getUser().getNickname())
+        .toList();
   }
 
   // === Private Helper Methods ===


### PR DESCRIPTION
   ### 변경사항
- 좋아요 리스트 조회 기능(`GET /api/v1/shelters/{shelterId}/likes`)
  - LikeRepository에 `findByShelter_ShelterId(String shelterId)` 메서드 추가
  - ShelterService에 `getShelterLikeUsers(String shelterId)` 메서드 추가
    - 해당 쉼터에 좋아요를 누른 사용자들의 닉네임 리스트 반환
  - `ShelterController에 /likes` 조회 API 추가
  
   ### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [X] API 테스트 